### PR TITLE
Fix [FchSmmSwDispatcher]: GCC Linker error due multiple definition of  mSmmCpuProtocol

### DIFF
--- a/AgesaModulePkg/Fch/9004/Fch9004SmmDispatcher/FchSmmSwDispatcher.c
+++ b/AgesaModulePkg/Fch/9004/Fch9004SmmDispatcher/FchSmmSwDispatcher.c
@@ -21,7 +21,6 @@
 
 extern UINT16 mSwSmiCmdAddress;
 
-EFI_SMM_CPU_PROTOCOL         *mSmmCpuProtocol;
 FCH_SMM_SW_NODE              *HeadFchSmmSwNodePtr;
 
 EFI_STATUS

--- a/AgesaModulePkg/Fch/9004/Fch9004SmmDispatcher/FchSmmSwDispatcher.h
+++ b/AgesaModulePkg/Fch/9004/Fch9004SmmDispatcher/FchSmmSwDispatcher.h
@@ -50,4 +50,5 @@ typedef struct _FCH_SMM_SW_NODE {
 #define MAX_SW_SMI_VALUE              0xFF
 extern  FCH_SMM_SW_NODE               *HeadFchSmmSwNodePtr;
 extern  FCH_SMM_SW_CONTEXT            *EfiSmmSwContext;
+extern  EFI_SMM_CPU_PROTOCOL          *mSmmCpuProtocol;
 #endif


### PR DESCRIPTION
GCC build fails because `mSmmCpuProtocol` is defined twice

[FchSmmDispatcher.c](https://github.com/openSIL/AGCL-R/blob/c5b724dca1b836b2f080375d2cf002e1735ef0fe/AgesaModulePkg/Fch/9004/Fch9004SmmDispatcher/FchSmmDispatcher.c#L22)

[FchSmmSwDispatcher.c](https://github.com/openSIL/AGCL-R/blob/c5b724dca1b836b2f080375d2cf002e1735ef0fe/AgesaModulePkg/Fch/9004/Fch9004SmmDispatcher/FchSmmSwDispatcher.c#L24)

This change becomes `mSmmCpuProtocol` external because:
- It is initialized by `FchSmmDispatcher:FchSmmDispatcherEntry` 
- It is consumed by `FchSmmSwDispatcher:FchSmmSwDispatchHandler`
